### PR TITLE
Bump proc-macro2 from 1.0.56 to 1.0.81

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
proc-macro2 v1.0.56, the current version in use, gives the following compiler error during `cargo build`:

    error[E0635]: unknown feature `proc_macro_span_shrink`
      --> /Users/futar/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/lib.rs:92:30
       |
    92 |     feature(proc_macro_span, proc_macro_span_shrink)
       |                              ^^^^^^^^^^^^^^^^^^^^^^

Which was fixed in 1.0.60+ (ref to https://github.com/dtolnay/proc-macro2/issues/398).